### PR TITLE
Fix altitude in meters issue in MK1

### DIFF
--- a/SAM7s_base/gps_mtk/gps_device_mtk3339.c
+++ b/SAM7s_base/gps_mtk/gps_device_mtk3339.c
@@ -92,8 +92,9 @@ static void parseGGA(GpsSample * gpsSample, char *data)
             gpsSample->DOP = modp_atof(data);
             break;
         case 8:
-            gpsSample->altitude = modp_atof(data);
-            break;
+                /* Convert Meters to Ft.  Because MURICA! */
+                gpsSample->altitude = modp_atof(data) * 3.28084;
+                break;
         }
 
         param++;


### PR DESCRIPTION
MK1 uses NMEA, which reports things in SI (like meters).  We current
use imperial measurements (X rods to Y hogshead in example).  This
converts altitude to Ft from Meters.  Go America!
